### PR TITLE
Update Terra2 RPC

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -23,7 +23,7 @@ const MAINNET_RPCS: { [key in Chain]?: string } = {
   Solana: "https://api.mainnet-beta.solana.com",
   Sui: "https://rpc.mainnet.sui.io",
   Terra: "https://terra-classic-fcd.publicnode.com",
-  Terra2: "https://phoenix-lcd.terra.dev",
+  Terra2: "https://lcd-terra.tfl.foundation",
   Xpla: "https://dimension-lcd.xpla.dev",
 };
 


### PR DESCRIPTION
Terraform Labs is deprecating phoenix-lcd.terra.dev. https://lcd-terra.tfl.foundation should be used instead